### PR TITLE
coopertition

### DIFF
--- a/properties/abilities/coopertition.md
+++ b/properties/abilities/coopertition.md
@@ -1,7 +1,7 @@
 # coopertition
 
 ## Definition
-If the robot's alliance met the coopertiton requirements (regardless of whether or not the other alliance reciprocated.)
+If the robot's alliance met the coopertition requirements (regardless of whether or not the other alliance reciprocated).
 
 ## Values
 This property stores a boolean (true/false) value
@@ -11,4 +11,4 @@ This property stores a boolean (true/false) value
 - false
 
 ## Design Recommendation
-This property can be implemented as a checkbox or toggle switch
+This property can be implemented as a checkbox or toggle switch, where a user can check the box or toggle the switch if the robot's alliance met the coopertition requirements

--- a/properties/abilities/coopertition.md
+++ b/properties/abilities/coopertition.md
@@ -1,0 +1,14 @@
+# coopertition
+
+## Definition
+If the robot's alliance met the coopertiton requirements (regardless of whether or not the other alliance reciprocated.)
+
+## Values
+This property stores a boolean (true/false) value
+
+## Examples
+- true
+- false
+
+## Design Recommendation
+This property can be implemented as a checkbox or toggle switch


### PR DESCRIPTION
There is some sort of coopertition every year, it is often useful to scout whether or not an alliance has qualified for it even if they end up not getting the coopetition bonus because the other alliance didn't also meet the requirements.

In 2024 we are scouting whether or not the yellow light on the amp has been activated by the current robot's alliance.