### PR TITLE
Remove extra commas

### DIFF
--- a/examples/tpw-2024-multiple-entries.json
+++ b/examples/tpw-2024-multiple-entries.json
@@ -5,23 +5,23 @@
 					"scouter": {
 						"name": "omkar",
 						"team": "1072",
-						"app": "tpw",
+						"app": "tpw"
 					},
 					"event": "2024camb",
 					"bot": "9999",
 					"match": {
 						"level": "qm",
 						"number": 1,
-						"set": 1,
+						"set": 1
 					},
-					"timestamp": 1704604894,
+					"timestamp": 1704604894
 				},
 				"abilities": {
 					"auto-leave-starting-zone": true,
 					"ground-pick-up": false,
 					"auto-center-line-pick-up": false,
 					"teleop-spotlight-2024": false,
-					"teleop-stage-level-2024": 2,
+					"teleop-stage-level-2024": 2
 				},
 				"counters": {
 
@@ -29,43 +29,43 @@
 				"data": {
 					"auto-scoring-2024": ["as", "sm"],
 					"teleop-scoring-2024": ["ss", "as", "am", "as", "sa", "sm", "tm", "ts"],
-					"notes": "Overall bot was good and had cool RGB :)",
+					"notes": "Overall bot was good and had cool RGB :)"
 				},
 				"ratings": {
 					"driver-skill": 4,
 					"defense-skill": 0,
 					"speed": 3,
 					"stability": 2,
-					"intake-consistency": 5,
+					"intake-consistency": 5
 				},
 				"timers": {
 					"stage-time-2024": 6023,
 					"brick-time": 0,
-					"defense-time": 0,
-				},
+					"defense-time": 0
+				}
 			},
 			{
 				"metadata": {
 					"scouter": {
 						"name": "kabir",
 						"team": "1072",
-						"app": "tpw",
+						"app": "tpw"
 					},
 					"event": "2024camb",
 					"bot": "9998",
 					"match": {
 						"level": "qm",
 						"number": 1,
-						"set": 1,
+						"set": 1
 					},
-					"timestamp": 1704605632,
+					"timestamp": 1704605632
 				},
 				"abilities": {
 					"auto-leave-starting-zone": true,
 					"ground-pick-up": true,
 					"auto-center-line-pick-up": true,
 					"teleop-spotlight-2024": true,
-					"teleop-stage-level-2024": 3,
+					"teleop-stage-level-2024": 3
 				},
 				"counters": {
 
@@ -73,20 +73,20 @@
 				"data": {
 					"auto-scoring-2024": ["as", "ss", "as"],
 					"teleop-scoring-2024": ["as", "as", "as", "sa", "sm", "ss", "as", "am", "as", "sa", "ts", "ts"],
-					"notes": "fast, scored consistently, low cycle times, good alliance partner strategies",
+					"notes": "fast, scored consistently, low cycle times, good alliance partner strategies"
 				},
 				"ratings": {
 					"driver-skill": 5,
 					"defense-skill": 0,
 					"speed": 4,
 					"stability": 3,
-					"intake-consistency": 5,
+					"intake-consistency": 5
 				},
 				"timers": {
 					"stage-time-2024": 2864,
 					"brick-time": 0,
-					"defense-time": 0,
-				},
+					"defense-time": 0
+				}
 			},
 			{
 				"metadata": {
@@ -94,7 +94,7 @@
 					"match": {
 						"level": "qm",
 						"number": 3,
-						"set": 1,
+						"set": 1
 					},
 					"bot": "9999",
 					"timestamp": 1711729092182,
@@ -102,7 +102,7 @@
 						"name": "kabir",
 						"team": "1072",
 						"app": "tpw"
-					},
+					}
 				},
 				"abilities": {
 					"auto-center-line-pick-up": false,

--- a/examples/tpw-2024.json
+++ b/examples/tpw-2024.json
@@ -4,7 +4,7 @@
 		"match": {
 			"level": "qm",
 			"number": 3,
-			"set": 1,
+			"set": 1
 		},
 		"bot": "9999",
 		"timestamp": 1711729092182,
@@ -12,7 +12,7 @@
 			"name": "kabir",
 			"team": "1072",
 			"app": "tpw"
-		},
+		}
 	},
 	"abilities": {
 		"auto-center-line-pick-up": false,


### PR DESCRIPTION
JavaScript's `JSON.parse()` failed to read your examples due to the extra commas.  Confirmed that trailing commas are not legal JSON. `jq`  on the command line fails a lint check.  vscode  highlights them as errors when editing the files.